### PR TITLE
fix: 悬浮窗 ESC 键相关问题

### DIFF
--- a/FishersIntuition/Windows/TimerWindow.cs
+++ b/FishersIntuition/Windows/TimerWindow.cs
@@ -16,6 +16,7 @@ internal class TimerWindow : Window
     public TimerWindow() : base("FishersIntuitionTimerWindow")
     {
         IsOpen = true;
+        RespectCloseHotkey = false;
         SizeCondition = ImGuiCond.FirstUseEver;
         SizeConstraints = new WindowSizeConstraints
         {


### PR DESCRIPTION
禁用 ESC 键关闭窗口，解决了两个问题：

1. 在悬浮窗出现时按下 ESC 键，窗口自动隐藏后无法再次出现。
2. 小概率导致全局 ESC 键失效，禁用插件再启用才能恢复。